### PR TITLE
Removed archive.org donation email

### DIFF
--- a/about.php
+++ b/about.php
@@ -577,9 +577,7 @@ and
 			   <h2 id=donate>How do I make a donation to support the HTTP Archive?</h2>
 <p>
 The HTTP Archive is part of the Internet Archive, a 501(c)(3) non-profit.
-Donations in support of the HTTP Archive can be made through the Internet Archive's 
-<a href="http://www.archive.org/donate/index.php">donation page</a>.
-Make sure to send a follow-up email to <a href="mailto:donations@archive.org">donations@archive.org</a> designating your donation to the "HTTP Archive".
+Donations in support of the HTTP Archive can be made through the Internet Archive.
 <a href='https://discuss.httparchive.org/'>Contact us</a> for more information and to get your logo added to this page.
 </p>
 

--- a/about.php
+++ b/about.php
@@ -578,7 +578,7 @@ and
 <p>
 The HTTP Archive is part of the Internet Archive, a 501(c)(3) non-profit.
 Donations in support of the HTTP Archive can be made through the Internet Archive.
-<a href='https://discuss.httparchive.org/'>Contact us</a> for more information and to get your logo added to this page.
+<a href='mailto:donations@httparchive.org'>Contact us</a> for more information and to get your logo added to this page.
 </p>
 
 			   <h2 id=contact>Who do I contact for more information?</h2>


### PR DESCRIPTION
Use the normal discussion contact path for donation inquiries. The email was getting nothing but spam.